### PR TITLE
Use NEXT_PUBLIC_ for env name

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -4,8 +4,8 @@ DATOCMS_READ_ONLY_API_TOKEN=a45ce78f9b2053c229bbfe9e3fca7b
 # If you’d like to enable GitHub OAuth, fill these below
 NEXT_PUBLIC_GITHUB_OAUTH_CLIENT_ID=
 GITHUB_OAUTH_CLIENT_SECRET=
-# To test GitHub OAuth locally, set SITE_ORIGIN as http://localhost:3000
-SITE_ORIGIN=http://localhost:3000
+# To test GitHub OAuth locally, set NEXT_PUBLIC_SITE_ORIGIN as http://localhost:3000
+NEXT_PUBLIC_SITE_ORIGIN=http://localhost:3000
 
 # If you’d like to use a Redis database to store user data in the API routes,
 # fill these below. See: lib/redis.ts

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ First, create a [GitHub OAuth application](https://docs.github.com/en/free-pro-t
 - Set the Authorization Callback URL as `http://localhost:3000/api/github-oauth` on GitHub.
 - On `.env.local`, set `NEXT_PUBLIC_GITHUB_OAUTH_CLIENT_ID` as the **Client ID** of the OAuth app.
 - Set `GITHUB_OAUTH_CLIENT_SECRET` as the **Client secret** of the OAuth app.
-- Finally, make sure the `SITE_ORIGIN` environment variable is set as `http://localhost:3000`. This is required to get the OAuth popup to work locally.
+- Finally, make sure the `NEXT_PUBLIC_SITE_ORIGIN` environment variable is set as `http://localhost:3000`. This is required to get the OAuth popup to work locally.
 - Restart the app (`yarn dev`) after editing `.env.local`.
 
 Once it’s set up, sign up on the registration form on the home page (not from a stage page) and then click "Generate with GitHub".

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -15,7 +15,7 @@
  */
 
 export const SITE_URL = 'https://demo.vercel.events';
-export const SITE_ORIGIN = process.env.SITE_ORIGIN || new URL(SITE_URL).origin;
+export const SITE_ORIGIN = process.env.NEXT_PUBLIC_SITE_ORIGIN || new URL(SITE_URL).origin;
 export const TWITTER_USER_NAME = 'vercel';
 export const BRAND_NAME = 'ACME';
 export const SITE_NAME_MULTILINE = ['ACME', 'Conf'];


### PR DESCRIPTION
Setting GitHub OAuth locally was failing because `NEXT_PUBLIC_` was not set and therefore the env var was `undefined` on client.