### PR TITLE
Fix invalid eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,6 @@
     "@typescript-eslint/no-explicit-any": 0,
     "@typescript-eslint/no-unsafe-assignment": 0,
     "@typescript-eslint/restrict-template-expressions": 0,
-    "@typescript-eslint/no-empty-function": 0,
+    "@typescript-eslint/no-empty-function": 0
   }
 }


### PR DESCRIPTION
You can reproduce the error by running `eslint .`.

below is the error message:
```bash
Oops! Something went wrong! :(

ESLint: 7.15.0

Failed to read JSON file at /Users/xxx/Code/virtual-event-starter-kit/.eslintrc.json:

Cannot read config file: /Users/xxx/Code/virtual-event-starter-kit/.eslintrc.json
Error: Unexpected token } in JSON at position 878

```

