### PR TITLE
Corrected a Possible Typo

### DIFF
--- a/components/layout.module.css
+++ b/components/layout.module.css
@@ -18,7 +18,7 @@
   background: #000;
   color: #fff;
   min-height: 100vh;
-  min-height: var(--100vh);
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
I noticed that this line of code is most likely a typo seeing as the `var()` keyword is wrapped around the value, `100vh`.