### PR TITLE
Fix broken "name OR 'them'" logic

### DIFF
--- a/components/ticket.tsx
+++ b/components/ticket.tsx
@@ -85,7 +85,7 @@ export default function Ticket({ username, name, ticketNumber, sharePage }: Prop
           <p className={cn(styles.description, styleUtils.appear, styleUtils['appear-second'])}>
             {sharePage ? (
               <>
-                Join {name && 'them '} on {DATE}.
+                Join {name ?? 'them'} on {DATE}.
               </>
             ) : (
               <>


### PR DESCRIPTION
The way it was will never show `name`. In fact, I think we can probably assume that `name` is truthy when `sharePage` is, but if not, it should show the name, and fall back to `'them'`.

Also, the `'them '` string had an extraneous space.

Thanks for this amazing repo! ❤️ 