### PR TITLE
bump node engine to support 12 and above

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://demo.vercel.events",
   "license": "Apache-2.0",
   "engines": {
-    "node": "12.x"
+    "node": ">=12"
   },
   "scripts": {
     "dev": "next",


### PR DESCRIPTION
A follow up PR regarding issue https://github.com/vercel/virtual-event-starter-kit/issues/51