### PR TITLE
fix: headless chrome not launching

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@agility/content-sync": "1.0.3",
     "@hcaptcha/react-hcaptcha": "^0.3.7",
     "@reach/skip-nav": "0.12.1",
-    "chrome-aws-lambda": "5.5.0",
+    "chrome-aws-lambda": "10.1.0",
     "classnames": "2.2.6",
     "cookie": "0.4.1",
     "date-fns": "2.16.1",


### PR DESCRIPTION
## Fixes
https://github.com/vercel/virtual-event-starter-kit/issues/70 