### PR TITLE
fix: remove deprected fields

### DIFF
--- a/lib/cms-providers/dato.ts
+++ b/lib/cms-providers/dato.ts
@@ -79,8 +79,6 @@ export async function getAllStages(): Promise<Stage[]> {
          slug
          stream
          discord
-         isLive
-         roomId
          schedule {
            title
            start


### PR DESCRIPTION
Deploy with Vercel reports an error due to deprecated fields.