### PR TITLE
Update DatoCMS manifest to work with 100ms

### DIFF
--- a/datocms.json
+++ b/datocms.json
@@ -4,6 +4,7 @@
   "previewImage": "https://demo.vercel.events/twitter-card.png",
   "datocmsProjectId": "37685",
   "deploymentType": "vercel",
+  "vercelIntegrationIds": ["oac_7yeSwUoVR5no3SlA9WM6oR7l"],
   "buildCommand": "npm run build",
   "datocmsApiTokenEnvName": "DATOCMS_READ_ONLY_API_TOKEN",
   "livePreviewUrl": "https://demo.vercel.events/"


### PR DESCRIPTION
For the integration with DatoCMS to work correctly, the `datocms.json` manifest file needs to specify a different Vercel Integration ID (DatoCMS + 100ms) instead of the default one (just DatoCMS).