### PR TITLE
image to fill parent container on mobile

### DIFF
--- a/components/speakers-grid.tsx
+++ b/components/speakers-grid.tsx
@@ -41,6 +41,7 @@ export default function SpeakersGrid({ speakers }: Props) {
                 blurDataURL={speaker.image.blurDataURL}
                 width={300}
                 height={300}
+                layout="responsive"
               />
             </div>
             <div className={styles.cardBody}>


### PR DESCRIPTION
Using responsive layout fills the speaker image in the speaker card on the mobile layout. Currently, on the mobile layout there's a gap on the right.